### PR TITLE
Fix the double classpath if update

### DIFF
--- a/realmtech-install.ps1
+++ b/realmtech-install.ps1
@@ -67,8 +67,9 @@ if (!(Test-Path -Path $realmtechLauncherDirectoryBin)) {
 }
 if (!(Test-Path -Path $realmtechLauncherDirectoryLib)) {
 	New-Item -ItemType Directory -Path $realmtechLauncherDirectoryLib
+}else{
+	Remove-Item -Path $realmtechLauncherDirectoryLib* -Recurse -Force
 }
-
 
 wget https://chattonf01.emf-informatique.ch/RealmTech/favicon.ico -o "$($realmtechLauncherDirectoryLib)favicon.icon"
 

--- a/realmtech-install.ps1
+++ b/realmtech-install.ps1
@@ -116,11 +116,10 @@ Remove-Item $tempZip
 $folderName = "$($realmtechLauncherDirectory)$($realmtechName)" -replace ".{4}$"
 robocopy $folderName $realmtechLauncherDirectory /S /Move /np /nfl /NDL /NJH /NJS
 
-try {
+if (Test-Path -Path $realmtechLauncherDirectory) {
 	rm $folderName -Recurse -Force
-} catch {
-
 }
+
 # create shortcut on desktop
 $title    = 'Create shortcut on desktop'
 $question = 'Do you want create a shortcut on your desktop'

--- a/realmtech-install.sh
+++ b/realmtech-install.sh
@@ -43,7 +43,7 @@ rootPath="$HOME"/.local/RealmTechData
 launcherPath="$rootPath/launcher"
 
 mkdir -p "$launcherPath"
-
+rm -rf "$launcherPath"
 curl -# -L -o "$launcherPath/temp.tar" "$downloadUrl"
 if ! test -e "$launcherPath/temp.tar"; then
     echo "Download Failed exiting..."

--- a/realmtech-install.sh
+++ b/realmtech-install.sh
@@ -43,7 +43,7 @@ rootPath="$HOME"/.local/RealmTechData
 launcherPath="$rootPath/launcher"
 
 mkdir -p "$launcherPath"
-rm -rf "$launcherPath"
+rm -rf "$launcherPath"/lib/*
 curl -# -L -o "$launcherPath/temp.tar" "$downloadUrl"
 if ! test -e "$launcherPath/temp.tar"; then
     echo "Download Failed exiting..."


### PR DESCRIPTION
If you were to update the launcher to 0.1.1 while still having 0.1.0 java will have two .jar and will not know wich one to choose. i updated the script so at every install it deletes the content of the lib directory thus preventing this issue to occure.